### PR TITLE
optimization policy check and test code

### DIFF
--- a/src/main/java/com/webank/weid/protocol/base/PresentationPolicyE.java
+++ b/src/main/java/com/webank/weid/protocol/base/PresentationPolicyE.java
@@ -19,6 +19,7 @@
 
 package com.webank.weid.protocol.base;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -92,8 +93,15 @@ public class PresentationPolicyE extends Version implements JsonSerializer {
     public static PresentationPolicyE create(String policyFileName) {
         PresentationPolicyE policy = null;
         try {
+            JsonNode jsonNode = null;
             //获取policyJson文件 转换成JsonNode
-            JsonNode jsonNode = JsonLoader.fromResource("/" + policyFileName);
+            File file = new File(policyFileName);
+            if (file.exists()) {
+                jsonNode = JsonLoader.fromFile(file);
+            } else {
+                jsonNode = JsonLoader.fromResource("/" + policyFileName);
+            }
+           
             if (jsonNode == null) {
                 logger.error("can not find the {} file in your classpath.", policyFileName);
                 return policy;

--- a/src/main/java/com/webank/weid/service/impl/CredentialPojoServiceImpl.java
+++ b/src/main/java/com/webank/weid/service/impl/CredentialPojoServiceImpl.java
@@ -139,18 +139,16 @@ public class CredentialPojoServiceImpl extends BaseService implements Credential
         }
 
         //检查每个map里的key个数是否相同
-        Set<String> claimKeys = claim.keySet();
-        Set<String> saltKeys = salt.keySet();
-        
-        if (claimKeys.size() != saltKeys.size()) {
+        if (!claim.keySet().equals(salt.keySet())) {
             return false;
         }
+        
         //检查key值是否一致
         for (Map.Entry<String, Object> entry : disclosureMap.entrySet()) {
             String k = entry.getKey();
             Object v = entry.getValue();
-            //如果disclosureMap中的key 再claim或者claim中没有则返回false
-            if (!claim.containsKey(k) || !salt.containsKey(k)) {
+            //如果disclosureMap中的key在claim中没有则返回false
+            if (!claim.containsKey(k)) {
                 return false;
             }
             Object saltV = salt.get(k);
@@ -279,27 +277,28 @@ public class CredentialPojoServiceImpl extends BaseService implements Credential
         for (int i = 0; i < claimList.size(); i++) {
             Object claimObj = claimList.get(i);
             if (claimObj instanceof Map) {
-                HashMap claimHashMap = (HashMap)claimObj;
-                Object disclosureObj = disclosureList.get(0);
+                Object disclosureObj = disclosureList.size() == 0 ? null : disclosureList.get(0);
                 if (disclosureObj == null) {
                     disclosureList.add(new HashMap());
                 }
                 HashMap disclosureHashMap = (HashMap)disclosureList.get(0);
-                addKeyToPolicy(disclosureHashMap, claimHashMap);
+                addKeyToPolicy(disclosureHashMap, (HashMap)claimObj);
                 break;
             } else if (claimObj instanceof List) {
-                ArrayList claimArrayList = (ArrayList)claimObj;
                 Object disclosureObj = disclosureList.get(i);
                 if (disclosureObj == null) {
                     disclosureList.add(new ArrayList());
                 }
                 ArrayList disclosureArrayList = (ArrayList)disclosureList.get(i);
-                addKeyToPolicyList(disclosureArrayList, claimArrayList);
+                addKeyToPolicyList(disclosureArrayList, (ArrayList)claimObj);
             }
         }
     }
     
     private static boolean isSampleListForClaim(ArrayList claimList) {
+        if (CollectionUtils.isEmpty(claimList)) {
+            return true;
+        }
         Object claimObj = claimList.get(0);
         if (claimObj instanceof Map) {
             return false;

--- a/src/main/java/com/webank/weid/service/impl/CredentialPojoServiceImpl.java
+++ b/src/main/java/com/webank/weid/service/impl/CredentialPojoServiceImpl.java
@@ -71,17 +71,17 @@ public class CredentialPojoServiceImpl extends BaseService implements Credential
 
     private static final Logger logger = LoggerFactory.getLogger(CredentialPojoServiceImpl.class);
 
-    private static WeIdService weIdService = new WeIdServiceImpl();
+    private static  WeIdService weIdService = new WeIdServiceImpl();
 
     private static CptService cptService = new CptServiceImpl();
 
-    private static String NOT_DISCLOSED =
+    private static final String NOT_DISCLOSED =
         CredentialFieldDisclosureValue.NOT_DISCLOSED.getStatus().toString();
 
-    private static String DISCLOSED =
+    private static final String DISCLOSED =
         CredentialFieldDisclosureValue.DISCLOSED.getStatus().toString();
 
-    private static String EXISTED =
+    private static final String EXISTED =
         CredentialFieldDisclosureValue.EXISTED.getStatus().toString();
 
     /**
@@ -126,7 +126,7 @@ public class CredentialPojoServiceImpl extends BaseService implements Credential
         }
         return true;
     }
-
+    
     /**
      * 校验claim、salt和disclosureMap的格式是否一致.
      */
@@ -141,21 +141,20 @@ public class CredentialPojoServiceImpl extends BaseService implements Credential
         //检查每个map里的key个数是否相同
         Set<String> claimKeys = claim.keySet();
         Set<String> saltKeys = salt.keySet();
-        Set<String> disclosureKeys = disclosureMap.keySet();
-
-        if (claimKeys.size() != saltKeys.size() || saltKeys.size() != disclosureKeys.size()) {
+        
+        if (claimKeys.size() != saltKeys.size()) {
             return false;
         }
-
         //检查key值是否一致
         for (Map.Entry<String, Object> entry : disclosureMap.entrySet()) {
             String k = entry.getKey();
             Object v = entry.getValue();
-            Object saltV = salt.get(k);
-            Object claimV = claim.get(k);
-            if (!salt.containsKey(k) || !disclosureMap.containsKey(k)) {
+            //如果disclosureMap中的key 再claim或者claim中没有则返回false
+            if (!claim.containsKey(k) || !salt.containsKey(k)) {
                 return false;
             }
+            Object saltV = salt.get(k);
+            Object claimV = claim.get(k);
             if (v instanceof Map) {
                 //递归检查
                 if (!validCredentialMapArgs((HashMap) claimV, (HashMap) saltV, (HashMap) v)) {
@@ -234,7 +233,83 @@ public class CredentialPojoServiceImpl extends BaseService implements Credential
         }
         return true;
     }
-
+    
+    //向policy中补充缺失的key
+    private static void addKeyToPolicy(
+        Map<String, Object> disclosureMap,
+        Map<String, Object> claimMap
+    ) {
+        for (Map.Entry<String, Object> entry : claimMap.entrySet()) {
+            String claimK = entry.getKey();
+            Object claimV = entry.getValue();
+            if (claimV instanceof Map) {
+                HashMap claimHashMap = (HashMap)claimV;
+                if (!disclosureMap.containsKey(claimK)) {
+                    disclosureMap.put(claimK, new HashMap());
+                }
+                HashMap disclosureHashMap = (HashMap)disclosureMap.get(claimK);
+                addKeyToPolicy(disclosureHashMap, claimHashMap);
+            } else if (claimV instanceof List) {
+                ArrayList claimList = (ArrayList)claimV;
+                //判断claimList中是否包含Map结构，还是单一结构
+                boolean isSampleList = isSampleListForClaim(claimList);
+                if (isSampleList) {
+                    if (!disclosureMap.containsKey(claimK)) {
+                        disclosureMap.put(claimK, Integer.parseInt(NOT_DISCLOSED));
+                    }
+                } else {
+                    if (!disclosureMap.containsKey(claimK)) {
+                        disclosureMap.put(claimK, new ArrayList());
+                    }
+                    ArrayList disclosureList = (ArrayList)disclosureMap.get(claimK);
+                    addKeyToPolicyList(disclosureList, claimList);
+                }
+            } else {
+                if (!disclosureMap.containsKey(claimK)) {
+                    disclosureMap.put(claimK, Integer.parseInt(NOT_DISCLOSED));
+                }
+            }
+        }
+    }
+    
+    private static void addKeyToPolicyList(
+        ArrayList disclosureList,
+        ArrayList claimList
+    ) {
+        for (int i = 0; i < claimList.size(); i++) {
+            Object claimObj = claimList.get(i);
+            if (claimObj instanceof Map) {
+                HashMap claimHashMap = (HashMap)claimObj;
+                Object disclosureObj = disclosureList.get(0);
+                if (disclosureObj == null) {
+                    disclosureList.add(new HashMap());
+                }
+                HashMap disclosureHashMap = (HashMap)disclosureList.get(0);
+                addKeyToPolicy(disclosureHashMap, claimHashMap);
+                break;
+            } else if (claimObj instanceof List) {
+                ArrayList claimArrayList = (ArrayList)claimObj;
+                Object disclosureObj = disclosureList.get(i);
+                if (disclosureObj == null) {
+                    disclosureList.add(new ArrayList());
+                }
+                ArrayList disclosureArrayList = (ArrayList)disclosureList.get(i);
+                addKeyToPolicyList(disclosureArrayList, claimArrayList);
+            }
+        }
+    }
+    
+    private static boolean isSampleListForClaim(ArrayList claimList) {
+        Object claimObj = claimList.get(0);
+        if (claimObj instanceof Map) {
+            return false;
+        }
+        if (claimObj instanceof List) {
+            return isSampleListForClaim((ArrayList)claimObj);
+        }
+        return true;
+    }
+    
     private static void addSelectSalt(
         Map<String, Object> disclosureMap,
         Map<String, Object> saltMap,
@@ -269,7 +344,8 @@ public class CredentialPojoServiceImpl extends BaseService implements Credential
         Object saltV,
         Object claimV
     ) {
-        if (((Integer) value).equals(Integer.parseInt(NOT_DISCLOSED))) {
+        if (((Integer) value).equals(Integer.parseInt(NOT_DISCLOSED)) 
+            && claim.containsKey(disclosureKey)) {
             saltMap.put(disclosureKey, NOT_DISCLOSED);
             String hash =
                 CredentialPojoUtils.getFieldSaltHash(
@@ -524,7 +600,7 @@ public class CredentialPojoServiceImpl extends BaseService implements Credential
 
             Map<String, Object> disclosureMap = DataToolUtils
                 .deserialize(disclosure, HashMap.class);
-
+            
             if (!validCredentialMapArgs(claim, saltMap, disclosureMap)) {
                 logger.error(
                     "[createSelectiveCredential] create failed. message is {}",
@@ -533,6 +609,9 @@ public class CredentialPojoServiceImpl extends BaseService implements Credential
                 return new ResponseData<CredentialPojo>(null,
                     ErrorCode.CREDENTIAL_POLICY_FORMAT_DOSE_NOT_MATCH_CLAIM);
             }
+            // 补 policy
+            addKeyToPolicy(disclosureMap, claim);
+            // 加盐处理
             addSelectSalt(disclosureMap, saltMap, claim);
             credentialClone.setSalt(saltMap);
 
@@ -776,20 +855,18 @@ public class CredentialPojoServiceImpl extends BaseService implements Credential
                 }
             } else {
                 String disclosure = String.valueOf(disclosureV);
-                String salt = String.valueOf(saltV);
-                if (!disclosure.equals(NOT_DISCLOSED) && !disclosure.equals(DISCLOSED)
-                    && !disclosure.equals(EXISTED)) {
+               
+                if (saltV == null 
+                    || (!disclosure.equals(NOT_DISCLOSED) && !disclosure.equals(DISCLOSED)
+                        && !disclosure.equals(EXISTED))) {
                     logger.error(
                         "[verifyDisclosureAndSalt] policy disclosureValue {} illegal.",
                         disclosureMap
                     );
                     return ErrorCode.CREDENTIAL_POLICY_DISCLOSUREVALUE_ILLEGAL;
                 }
-
-                if (StringUtils.isEmpty(salt)) {
-                    return ErrorCode.CREDENTIAL_POLICY_DISCLOSUREVALUE_ILLEGAL;
-                }
-
+                
+                String salt = String.valueOf(saltV);
                 if ((disclosure.equals(NOT_DISCLOSED) && salt.length() > 1)
                     || (disclosure.equals(NOT_DISCLOSED) && !salt.equals(NOT_DISCLOSED))) {
                     return ErrorCode.CREDENTIAL_DISCLOSUREVALUE_NOTMATCH_SALTVALUE;

--- a/src/main/java/com/webank/weid/suite/persistence/sql/SqlExecutor.java
+++ b/src/main/java/com/webank/weid/suite/persistence/sql/SqlExecutor.java
@@ -82,6 +82,11 @@ public class SqlExecutor {
     private static final String DEFAULT_TABLE = "sdk_all_data";
     
     /**
+     * 表的默认前缀.
+     */
+    private static final String DEFAULT_TABLE_PREFIX = "weidentity_";
+    
+    /**
      * domain 分隔符.
      */
     private static final String SPLIT_CHAR = ":";
@@ -325,12 +330,13 @@ public class SqlExecutor {
         synchronized (TABLE_CACHE) {
             //说明本地没有此tableDomain
             if (StringUtils.isBlank(tableName)) {
+                tableName = getTableName();
                 //检查数据库中是否存在此表
                 ResponseData<String>  result =  this.executeQuery(checkTableSql);
                 //如果数据库中存在此表
-                if (tableDomain.equals(result.getResult())) {
+                if (tableName.equals(result.getResult())) {
                     //本地缓存记录此表
-                    TABLE_CACHE.put(tableDomain, tableDomain);
+                    TABLE_CACHE.put(tableDomain, tableName);
                     return;
                 }
                 //动态创建此表
@@ -342,16 +348,20 @@ public class SqlExecutor {
                 //再查询一次，确认是否创建成功
                 result =  this.executeQuery(checkTableSql);
                 //如果不相等 则表示创建失败
-                if (!tableDomain.equals(result.getResult())) {
+                if (!tableName.equals(result.getResult())) {
                     throw new WeIdBaseException(ErrorCode.PRESISTENCE_DOMAIN_INVALID);
                 }
                 //本地缓存记录此表
-                TABLE_CACHE.put(tableDomain, tableDomain);
+                TABLE_CACHE.put(tableDomain, tableName);
             }
         }
     }
     
     private String buildExecuteSql(String sql) {
-        return new StringBuffer(sql).toString().replace(TABLE_CHAR, tableDomain);
+        return new StringBuffer(sql).toString().replace(TABLE_CHAR, getTableName());
+    }
+    
+    private String getTableName() {
+        return new StringBuffer(DEFAULT_TABLE_PREFIX).append(tableDomain).toString();
     }
 }

--- a/src/test/java/com/webank/weid/full/MockMysqlDriver.java
+++ b/src/test/java/com/webank/weid/full/MockMysqlDriver.java
@@ -110,7 +110,8 @@ public interface MockMysqlDriver {
                         return new ResponseData<String>(
                             (String)mockDbMap.get(data[0]), ErrorCode.SUCCESS);
                     }
-                    return new ResponseData<String>(tableDomain, ErrorCode.SUCCESS);
+                    String tableName = (String)Deencapsulation.invoke(executor, "getTableName");
+                    return new ResponseData<String>(tableName, ErrorCode.SUCCESS);
                 }
                 return new ResponseData<String>(null, ErrorCode.SQL_EXECUTE_FAILED);
             }

--- a/src/test/java/com/webank/weid/full/auth/TestAddIssuerIntoIssuerType.java
+++ b/src/test/java/com/webank/weid/full/auth/TestAddIssuerIntoIssuerType.java
@@ -204,6 +204,7 @@ public class TestAddIssuerIntoIssuerType extends TestBaseServcie {
     /**
      * case: private key is belong other weId.
      */
+    @Test
     public void testAddIssuerIntoIssuerType_otherPriKey() {
         WeIdAuthentication weIdAuthentication = TestBaseUtil.buildWeIdAuthentication(createWeId);
         weIdAuthentication.setWeIdPrivateKey(createWeIdResult.getUserWeIdPrivateKey());
@@ -220,6 +221,7 @@ public class TestAddIssuerIntoIssuerType extends TestBaseServcie {
     /**
      * case: private key is belong other weId.
      */
+    @Test
     public void testAddIssuerIntoIssuerType_otherAuthorPriKey() {
         WeIdAuthentication weIdAuthentication = TestBaseUtil.buildWeIdAuthentication(createWeId);
         CreateWeIdDataResult weIdDataResult = super.registerAuthorityIssuer();

--- a/src/test/java/com/webank/weid/full/auth/TestRegisterAuthorityIssuer.java
+++ b/src/test/java/com/webank/weid/full/auth/TestRegisterAuthorityIssuer.java
@@ -233,7 +233,6 @@ public class TestRegisterAuthorityIssuer extends TestBaseServcie {
             TestBaseUtil.buildRegisterAuthorityIssuerArgs(createWeId, privateKey);
         registerAuthorityIssuerArgs.getAuthorityIssuer()
             .setCreated(-19600101L);
-        System.out.println(registerAuthorityIssuerArgs);
         ResponseData<Boolean> response = new ResponseData<>(false,
             ErrorCode.AUTHORITY_ISSUER_CONTRACT_ERROR_NAME_ALREADY_EXISTS);
 
@@ -858,7 +857,7 @@ public class TestRegisterAuthorityIssuer extends TestBaseServcie {
     public void testRegisterAuthorityIssuer_issuerNameIsDigtal() {
 
         RegisterAuthorityIssuerArgs registerAuthorityIssuerArgs =
-            TestBaseUtil.buildRegisterAuthorityIssuerArgs(createWeIdResult, privateKey);
+            TestBaseUtil.buildRegisterAuthorityIssuerArgs(super.createWeId(), privateKey);
 
         ResponseData<Boolean> response = new ResponseData<>(false,
             ErrorCode.AUTHORITY_ISSUER_CONTRACT_ERROR_NAME_ALREADY_EXISTS);
@@ -978,7 +977,6 @@ public class TestRegisterAuthorityIssuer extends TestBaseServcie {
             == ErrorCode.AUTHORITY_ISSUER_CONTRACT_ERROR_NAME_ALREADY_EXISTS.getCode()) {
             registerAuthorityIssuerArgs.getAuthorityIssuer()
                 .setName("！@#￥%……&*-+<>?x" + (int)(Math.random() * 1000));
-            System.out.println(registerAuthorityIssuerArgs.toString());
             response = authorityIssuerService.registerAuthorityIssuer(registerAuthorityIssuerArgs);
         }
         LogUtil.info(logger, "registerAuthorityIssuer", response);

--- a/src/test/java/com/webank/weid/full/auth/TestRegisterIssuerType.java
+++ b/src/test/java/com/webank/weid/full/auth/TestRegisterIssuerType.java
@@ -156,7 +156,6 @@ public class TestRegisterIssuerType extends TestBaseServcie {
             authorityIssuerService.registerIssuerType(weIdAuthentication, "");
         LogUtil.info(logger, "registerIssuerType", response);
 
-        System.out.println(response);
         Assert.assertEquals(ErrorCode.ILLEGAL_INPUT.getCode(), response.getErrorCode().intValue());
         Assert.assertFalse(response.getResult());
     }
@@ -175,7 +174,6 @@ public class TestRegisterIssuerType extends TestBaseServcie {
             authorityIssuerService.registerIssuerType(weIdAuthentication, name);
         LogUtil.info(logger, "registerIssuerType", response);
 
-        System.out.println(response);
         Assert.assertEquals(ErrorCode.SPECIFIC_ISSUER_TYPE_ILLEGAL.getCode(),
             response.getErrorCode().intValue());
         Assert.assertFalse(response.getResult());

--- a/src/test/java/com/webank/weid/full/auth/TestRemoveIssuerFromIssuerType.java
+++ b/src/test/java/com/webank/weid/full/auth/TestRemoveIssuerFromIssuerType.java
@@ -126,7 +126,6 @@ public class TestRemoveIssuerFromIssuerType extends TestBaseServcie {
         LogUtil.info(logger, "removeIssuerFromIssuerType", response);
 
         callerAuth.setWeIdPrivateKey(key);
-        System.out.println(callerAuth.toString());
 
         Assert.assertEquals(ErrorCode.AUTHORITY_ISSUER_PRIVATE_KEY_ILLEGAL.getCode(),
             response.getErrorCode().intValue());

--- a/src/test/java/com/webank/weid/full/cpt/TestRegisterCptArgs.java
+++ b/src/test/java/com/webank/weid/full/cpt/TestRegisterCptArgs.java
@@ -76,7 +76,6 @@ public class TestRegisterCptArgs extends TestBaseServcie {
 
         ResponseData<CptBaseInfo> response = cptService.registerCpt(registerCptArgs);
         LogUtil.info(logger, "registerCpt", response);
-        System.out.println(registerCptArgs);
 
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         CptBaseInfo cptBaseInfo = response.getResult();
@@ -85,7 +84,6 @@ public class TestRegisterCptArgs extends TestBaseServcie {
 
         Integer cptId = cptBaseInfo.getCptId();
         ResponseData<Cpt> reponse = cptService.queryCpt(cptId);
-        System.out.println(reponse);
     }
 
     /**
@@ -102,7 +100,6 @@ public class TestRegisterCptArgs extends TestBaseServcie {
 
         ResponseData<CptBaseInfo> response = cptService.registerCpt(registerCptArgs);
         LogUtil.info(logger, "registerCpt", response);
-        System.out.println(registerCptArgs);
 
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         CptBaseInfo cptBaseInfo = response.getResult();
@@ -151,14 +148,11 @@ public class TestRegisterCptArgs extends TestBaseServcie {
 
         ResponseData<CptBaseInfo> response = cptService.registerCpt(registerCptArgs);
         LogUtil.info(logger, "registerCpt", response);
-        System.out.println(registerCptArgs);
 
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         CptBaseInfo cptBaseInfo = response.getResult();
-        System.out.println(cptBaseInfo);
         Assert.assertTrue(cptBaseInfo.getCptId().intValue() > 1000);
         Assert.assertTrue(cptBaseInfo.getCptId().intValue() < 3000000);
-
     }
 
     /**
@@ -239,7 +233,6 @@ public class TestRegisterCptArgs extends TestBaseServcie {
         cptJsonSchema.put("name", "rocky xia is good man");
         cptJsonSchema.put("年龄", 18);
         cptJsonSchema.put("account", 192.5);
-        System.out.println(cptMapArgs);
 
         ResponseData<CptBaseInfo> response = cptService.registerCpt(cptMapArgs);
         LogUtil.info(logger, "registerCpt", response);
@@ -298,7 +291,6 @@ public class TestRegisterCptArgs extends TestBaseServcie {
 
         ResponseData<CptBaseInfo> response = cptService.registerCpt(registerCptArgs);
         LogUtil.info(logger, "registerCpt", response);
-        System.out.println(registerCptArgs);
 
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         CptBaseInfo cptBaseInfo = response.getResult();

--- a/src/test/java/com/webank/weid/full/cpt/TestRegisterCptArgsWithId.java
+++ b/src/test/java/com/webank/weid/full/cpt/TestRegisterCptArgsWithId.java
@@ -124,7 +124,6 @@ public class TestRegisterCptArgsWithId extends TestBaseServcie {
         ResponseData<CptBaseInfo> response = cptService.registerCpt(registerCptArgs, issuerCptId);
         LogUtil.info(logger, "testRegisterCptArgs with cptid", response);
 
-        System.out.println(response);
         Assert.assertEquals(ErrorCode.CPT_NO_PERMISSION.getCode(),
             response.getErrorCode().intValue());
         Assert.assertNull(response.getResult());
@@ -147,7 +146,6 @@ public class TestRegisterCptArgsWithId extends TestBaseServcie {
         ResponseData<CptBaseInfo> response = cptService.registerCpt(registerCptArgs, issuerCptId);
         LogUtil.info(logger, "testRegisterCptArgs with cptid", response);
 
-        System.out.println(response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertNotNull(response.getResult());
     }
@@ -268,7 +266,6 @@ public class TestRegisterCptArgsWithId extends TestBaseServcie {
         cptJsonSchema.put("name", "rocky xia is good man");
         cptJsonSchema.put("年龄", 18);
         cptJsonSchema.put("account", 192.5);
-        System.out.println(cptMapArgs);
 
         Integer issuerCptId = 20000;
         while (cptService.queryCpt(issuerCptId).getResult() != null) {

--- a/src/test/java/com/webank/weid/full/cpt/TestRegisterCptStringArgsWithId.java
+++ b/src/test/java/com/webank/weid/full/cpt/TestRegisterCptStringArgsWithId.java
@@ -118,7 +118,6 @@ public class TestRegisterCptStringArgsWithId extends TestBaseServcie {
         ResponseData<CptBaseInfo> response = cptService.registerCpt(registerCptArgs, issuerCptId);
         LogUtil.info(logger, "testRegisterCptArgs with cptid", response);
 
-        System.out.println(response);
         Assert.assertEquals(ErrorCode.CPT_NO_PERMISSION.getCode(),
             response.getErrorCode().intValue());
         Assert.assertNull(response.getResult());

--- a/src/test/java/com/webank/weid/full/credential/TestCreateCredential.java
+++ b/src/test/java/com/webank/weid/full/credential/TestCreateCredential.java
@@ -61,7 +61,6 @@ public class TestCreateCredential extends TestBaseServcie {
 
         CreateCredentialArgs createCredentialArgs =
             TestBaseUtil.buildCreateCredentialArgs(createWeIdResultWithSetAttr, cptBaseInfo);
-        System.out.println(createCredentialArgs);
 
         ResponseData<CredentialWrapper> response =
             credentialService.createCredential(createCredentialArgs);

--- a/src/test/java/com/webank/weid/full/credentialpojo/TestCreateSelectiveCredential.java
+++ b/src/test/java/com/webank/weid/full/credentialpojo/TestCreateSelectiveCredential.java
@@ -557,9 +557,9 @@ public class TestCreateSelectiveCredential extends TestBaseServcie {
             credentialPojoService.createSelectiveCredential(credentialPojo, claimPolicy);
         LogUtil.info(logger, "TestCreateSelectiveCredential", response);
 
-        Assert.assertEquals(ErrorCode.CREDENTIAL_POLICY_FORMAT_DOSE_NOT_MATCH_CLAIM.getCode(),
+        Assert.assertEquals(ErrorCode.SUCCESS.getCode(),
             response.getErrorCode().intValue());
-        Assert.assertNull(response.getResult());
+        Assert.assertNotNull(response.getResult());
     }
 
     /**

--- a/src/test/java/com/webank/weid/full/persistence/TestGet.java
+++ b/src/test/java/com/webank/weid/full/persistence/TestGet.java
@@ -93,7 +93,6 @@ public class TestGet extends TestBaseTransportation {
     @Test
     public void testGet_TableNotExist() {
         String dataSource = domain.split(":")[0];
-        System.out.println(dataSource);
         ResponseData<String> res = persistence.get(
             dataSource + ":table_not_exist", "123456");
         LogUtil.info(logger, "persistence", res);

--- a/src/test/java/com/webank/weid/full/transportation/TestJsonSpecify.java
+++ b/src/test/java/com/webank/weid/full/transportation/TestJsonSpecify.java
@@ -23,7 +23,6 @@ public class TestJsonSpecify extends TestBaseServcie {
         weIdList.add(createWeIdResult.getWeId());
         weIdList.add(createWeIdNew.getWeId());
         jsonTransportation = jsonTransportation.specify(weIdList);
-        System.out.println(jsonTransportation);
         Assert.assertNotNull(jsonTransportation);
         
     }

--- a/src/test/java/com/webank/weid/full/weid/TestCreateWeId1.java
+++ b/src/test/java/com/webank/weid/full/weid/TestCreateWeId1.java
@@ -66,12 +66,10 @@ public class TestCreateWeId1 extends TestBaseServcie {
 
         ResponseData<CreateWeIdDataResult> response = weIdService.createWeId();
         LogUtil.info(logger, "createWeId", response);
-        System.out.println(response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertNotNull(response.getResult());
         ResponseData<CreateWeIdDataResult> response1 = weIdService.createWeId();
         LogUtil.info(logger, "createWeId", response1);
-        System.out.println(response1);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response1.getErrorCode().intValue());
         Assert.assertNotNull(response1.getResult());
         Assert.assertNotEquals(response.getResult().getWeId(), response1.getResult().getWeId());

--- a/src/test/java/com/webank/weid/full/weid/TestCreateWeId2.java
+++ b/src/test/java/com/webank/weid/full/weid/TestCreateWeId2.java
@@ -209,7 +209,6 @@ public class TestCreateWeId2 extends TestBaseServcie {
     public void testCreateWeId_pubKeyUsed() {
         CreateWeIdArgs createWeIdArgs = TestBaseUtil.buildCreateWeIdArgs();
         String publicKey = createWeIdArgs.getPublicKey();
-        System.out.println(publicKey);
         ResponseData<String> response = weIdService.createWeId(createWeIdArgs);
         LogUtil.info(logger, "createWeId", response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());

--- a/src/test/java/com/webank/weid/full/weid/TestGetWeIdDocumentJson.java
+++ b/src/test/java/com/webank/weid/full/weid/TestGetWeIdDocumentJson.java
@@ -138,7 +138,6 @@ public class TestGetWeIdDocumentJson extends TestBaseServcie {
         ResponseData<String> weIdDoc =
             weIdService.getWeIdDocumentJson("weid:did:123");
         LogUtil.info(logger, "getWeIdDocumentJson", weIdDoc);
-        System.out.println(weIdDoc);
         Assert.assertEquals(ErrorCode.WEID_INVALID.getCode(), weIdDoc.getErrorCode().intValue());
         Assert.assertEquals(StringUtils.EMPTY, weIdDoc.getResult());
     }
@@ -153,7 +152,6 @@ public class TestGetWeIdDocumentJson extends TestBaseServcie {
         ResponseData<String> weIdDoc =
             weIdService.getWeIdDocumentJson(weid);
         LogUtil.info(logger, "getWeIdDocumentJson", weIdDoc);
-        System.out.println(weIdDoc);
         Assert.assertEquals(ErrorCode.WEID_DOES_NOT_EXIST.getCode(),
             weIdDoc.getErrorCode().intValue());
         Assert.assertEquals(StringUtils.EMPTY, weIdDoc.getResult());
@@ -169,7 +167,6 @@ public class TestGetWeIdDocumentJson extends TestBaseServcie {
         ResponseData<String> weIdDoc =
             weIdService.getWeIdDocumentJson(weid);
         LogUtil.info(logger, "getWeIdDocumentJson", weIdDoc);
-        System.out.println(weIdDoc);
         Assert.assertEquals(ErrorCode.WEID_INVALID.getCode(), weIdDoc.getErrorCode().intValue());
         Assert.assertEquals(StringUtils.EMPTY, weIdDoc.getResult());
     }
@@ -183,7 +180,6 @@ public class TestGetWeIdDocumentJson extends TestBaseServcie {
         ResponseData<String> weIdDoc =
             weIdService.getWeIdDocumentJson(null);
         LogUtil.info(logger, "getWeIdDocumentJson", weIdDoc);
-        System.out.println(weIdDoc);
         Assert.assertEquals(ErrorCode.WEID_INVALID.getCode(), weIdDoc.getErrorCode().intValue());
         Assert.assertEquals(StringUtils.EMPTY, weIdDoc.getResult());
     }
@@ -197,11 +193,9 @@ public class TestGetWeIdDocumentJson extends TestBaseServcie {
         for (int i = 0; i < chars.length; i++) {
             chars[i] = (char) (i % 127);
         }
-        System.out.println(Arrays.toString(chars));
         ResponseData<String> weIdDoc =
             weIdService.getWeIdDocumentJson(Arrays.toString(chars));
         LogUtil.info(logger, "getWeIdDocumentJson", weIdDoc);
-        System.out.println(weIdDoc);
         Assert.assertEquals(ErrorCode.WEID_INVALID.getCode(), weIdDoc.getErrorCode().intValue());
         Assert.assertEquals(StringUtils.EMPTY, weIdDoc.getResult());
     }

--- a/src/test/java/com/webank/weid/full/weid/TestSetAuthentication.java
+++ b/src/test/java/com/webank/weid/full/weid/TestSetAuthentication.java
@@ -194,7 +194,6 @@ public class TestSetAuthentication extends TestBaseServcie {
         List<String> arrayList = Arrays.asList("*", "+", "=");
         for (String c : arrayList) {
             weId = weId + c;
-            System.out.println(c);
             setAuthenticationArgs.setWeId(weId);
 
             ResponseData<Boolean> response = weIdService.setAuthentication(setAuthenticationArgs);

--- a/src/test/java/com/webank/weid/full/weid/TestSetPublicKey.java
+++ b/src/test/java/com/webank/weid/full/weid/TestSetPublicKey.java
@@ -79,7 +79,6 @@ public class TestSetPublicKey extends TestBaseServcie {
     public void testSetPublicKey_badFormat() {
 
         SetPublicKeyArgs setPublicKeyArgs = TestBaseUtil.buildSetPublicKeyArgs(createWeIdResult);
-        System.out.println(setPublicKeyArgs);
         setPublicKeyArgs.setWeId("di:weid:0xbbd97a63365b6c9fb6b011a8d294307a3b7dac73");
 
         ResponseData<Boolean> response = weIdService.setPublicKey(setPublicKeyArgs);
@@ -173,7 +172,6 @@ public class TestSetPublicKey extends TestBaseServcie {
         ResponseData<Boolean> response = weIdService.setPublicKey(setPublicKeyArgs);
         LogUtil.info(logger, "setPublicKey", response);
 
-        System.out.println(response);
         Assert.assertEquals(ErrorCode.SUCCESS.getCode(), response.getErrorCode().intValue());
         Assert.assertEquals(true, response.getResult());
     }
@@ -356,9 +354,7 @@ public class TestSetPublicKey extends TestBaseServcie {
             chars[i] = (char) (i % 127);
         }
         String owner = String.valueOf(chars);
-        System.out.println(owner);
         setPublicKeyArgs.setOwner(owner);
-        System.out.println(setPublicKeyArgs);
         ResponseData<Boolean> response = weIdService.setPublicKey(setPublicKeyArgs);
         LogUtil.info(logger, "setPublicKey", response);
 


### PR DESCRIPTION
## Summary
1. 支持policy比claim少key的情况，但要求格式相同，并且policy不能多余claim
2. 动态创建表添加默认前缀
3. 修复测试代码多余的输出语句
4. 修复测试用例
5. 创建policy支持传入指定policy文件路径
