### PR TITLE
* EvidenceInfo output uses WeID for signers instead of address

### DIFF
--- a/src/main/java/com/webank/weid/service/impl/engine/fiscov1/EvidenceServiceEngineV1.java
+++ b/src/main/java/com/webank/weid/service/impl/engine/fiscov1/EvidenceServiceEngineV1.java
@@ -285,7 +285,7 @@ public class EvidenceServiceEngineV1 extends BaseEngine implements EvidenceServi
 
             List<String> signerStringList = new ArrayList<>();
             for (Address addr : issuerList) {
-                signerStringList.add(addr.toString());
+                signerStringList.add(WeIdUtils.convertAddressToWeId(addr.toString()));
             }
             evidenceInfoData.setSigners(signerStringList);
 

--- a/src/main/java/com/webank/weid/service/impl/engine/fiscov2/EvidenceServiceEngineV2.java
+++ b/src/main/java/com/webank/weid/service/impl/engine/fiscov2/EvidenceServiceEngineV2.java
@@ -259,7 +259,7 @@ public class EvidenceServiceEngineV2 extends BaseEngine implements EvidenceServi
 
             List<String> signerStringList = new ArrayList<>();
             for (String addr : issuerList) {
-                signerStringList.add(addr);
+                signerStringList.add(WeIdUtils.convertAddressToWeId(addr));
             }
             evidenceInfoData.setSigners(signerStringList);
 

--- a/src/test/java/com/webank/weid/full/evidence/TestCreateEvidence.java
+++ b/src/test/java/com/webank/weid/full/evidence/TestCreateEvidence.java
@@ -604,7 +604,7 @@ public class TestCreateEvidence extends TestBaseServcie {
         Assert.assertEquals(eviInfo.getSigners().size(), 3);
         List<String> signersAddrList = new ArrayList<>();
         for (String weId : signersList) {
-            signersAddrList.add(WeIdUtils.convertWeIdToAddress(weId));
+            signersAddrList.add(weId);
         }
         List<String> onChainSigners = eviInfo.getSigners();
         for (String weId : signersAddrList) {


### PR DESCRIPTION
* Add extra check for illegal object format in evi creation

## Summary
- Concisely describe the issue and your solution:
- Link to existing issue (type "#" to check):
- Specify the tests done so far:

## Solutions (Optional)
Please describe the details of your solution if it might be too complicated for reviewers.
